### PR TITLE
import bugfix

### DIFF
--- a/__version__.py
+++ b/__version__.py
@@ -1,0 +1,1 @@
+pyofo/__version__.py

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 
 from setuptools import setup
 
-from pyofo import __version__
+import __version__
+
 
 setup(
     name='pyofo',


### PR DESCRIPTION
Because setup.py tries to import `from pyofo import __version__` then `__init__.py` from pyofo is loaded, which contains `from .auth import *` which itself contains `from .config import set_proxies, set_auth, set_token`.

`config.py` is then loaded when reading `setup.py` and `config.py` contains an import from requests: `from requests.auth import HTTPProxyAuth`

That causes pip installations to fail if requests is not previously installed in the environment as it is trying to load requests at load time.

This creates a link to `__version__.py` outside pyofo so that `__init__.py` is not loaded by `setup.py`